### PR TITLE
Feat: Add type as error name to be more descriptive in logging tools

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const {
 
 function CustomError(type, message, extra) {
 	Error.captureStackTrace(this, this.constructor);
-	this.name = this.constructor.name;
+	this.name = type || this.constructor.name;
 	this.type = type;
 	this.message = message;
 	this.extra = extra;

--- a/test/unit/errorFactory.test.js
+++ b/test/unit/errorFactory.test.js
@@ -2,11 +2,11 @@ const { errorFactory } = require('../..');
 
 describe('errorFactory method', () => {
 	it('Error must return a Custom Error', () => {
-		const type = 'testError';
+		const type = 'TestError';
 		const message = 'Test error message';
 		const testError = errorFactory(type);
 		const errorProperties = testError(message);
-		expect(errorProperties.name).toEqual('CustomError');
+		expect(errorProperties.name).toEqual(type);
 		expect(errorProperties.type).toEqual(type);
 		expect(errorProperties.message).toEqual(message);
 	});

--- a/test/unit/handleHttpError.test.js
+++ b/test/unit/handleHttpError.test.js
@@ -16,7 +16,7 @@ describe('handleHttpError method', () => {
 
 	const reqMock = {};
 	it('Error must return a Custom Error with 500 as we do not setup a CustomErrorType', () => {
-		const type = 'testError';
+		const type = 'TestError';
 		const message = 'Test error message';
 		const testError = errorFactory(type);
 		const error = testError(message);


### PR DESCRIPTION
This PR includes a small refactor to add type as the name of the error so that error tooling will be more descriptive.